### PR TITLE
Add support for cmake builds and google tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,44 @@
+#---- PREAMBLE
+cmake_minimum_required(VERSION 3.5)
+project(VecOps CXX)
+set(CMAKE_CXX_STANDARD 11)
+add_compile_options(-Wall -Wextra -Wpedantic)
+
+#---- Make Release the default build type
+if (NOT CMAKE_BUILD_TYPE)
+	set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
+	message (STATUS "Build type not specified: defaulting to ${CMAKE_BUILD_TYPE}")
+endif()
+
+#---- FIND ROOT
+list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
+find_package(ROOT REQUIRED COMPONENTS TreePlayer)
+
+#---- FIND SYSTEM THREADING LIBRARY
+find_package(Threads REQUIRED)
+
+#---- FIND GTEST OR DOWNLOAD IT AND COMPILE IT
+enable_testing()
+find_package(GTest)
+if(GTest_FOUND)
+	include_directories(${GTEST_INCLUDE_DIRS})
+else()
+	message (STATUS "GTest will be downloaded and installed as part of the build step")
+	# Download and install googletest
+	include(ExternalProject)
+	ExternalProject_Add(googletest
+		URL https://github.com/google/googletest/archive/release-1.8.0.zip
+		URL_HASH SHA256=f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf
+		CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:string=${CMAKE_BINARY_DIR}/gtest)
+
+	# Add gtest to our build
+	include_directories(${CMAKE_BINARY_DIR}/gtest/include)
+	set(GTEST_BOTH_LIBRARIES ${CMAKE_BINARY_DIR}/gtest/lib/libgtest.a ${CMAKE_BINARY_DIR}/gtest/lib/libgtest_main.a)
+	set(EXTERNAL_GTEST TRUE)
+endif(GTest_FOUND)
+
+#--- BUILD LIBRARY
+add_subdirectory(src)
+
+#--- BUILD TESTS
+add_subdirectory(test)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(VecOps TVec.cxx)
+target_link_libraries(VecOps ${ROOT_LIBRARIES})
+target_include_directories(VecOps PUBLIC ${ROOT_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/inc)

--- a/src/TVec.cxx
+++ b/src/TVec.cxx
@@ -1,0 +1,1 @@
+#include <ROOT/TVec.hxx>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_executable(intro intro.C)
+target_link_libraries(intro VecOps ${ROOT_LIBRARIES})
+target_include_directories(intro PUBLIC ${CMAKE_SOURCE_DIR}/inc ${ROOT_INCLUDE_DIRS})
+
+function (add_google_test testname source)
+	add_executable(${testname} ${source})
+	target_link_libraries(${testname} VecOps ${ROOT_LIBRARIES} ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+	target_include_directories(${testname} PUBLIC ${CMAKE_SOURCE_DIR}/src ${ROOT_INCLUDE_DIRS})
+	if (EXTERNAL_GTEST)
+		add_dependencies(${testname} googletest)
+	endif()
+	add_test(${testname} ${testname})
+endfunction()
+
+add_google_test(vecops_unit vecops_unit.C)

--- a/test/vecops_unit.C
+++ b/test/vecops_unit.C
@@ -1,8 +1,58 @@
 #include <gtest/gtest.h>
-
 #include <ROOT/TVec.hxx>
+#include <vector>
 
 TEST(VecOps, DefaultCtor)
 {
-   ROOT::Experimental::VecOps::TVec<int>();
+   ROOT::Experimental::VecOps::TVec<int> v;
+   EXPECT_EQ(v.size(), 0u);
+}
+
+TEST(VecOps, InitListCtor)
+{
+   ROOT::Experimental::VecOps::TVec<int> v{1,2,3};
+   EXPECT_EQ(v.size(), 3u);
+   // FIXME uncomment when operator[] is fixed
+   //EXPECT_EQ(v[0], 1);
+   //EXPECT_EQ(v[1], 2);
+   //EXPECT_EQ(v[2], 3);
+}
+
+TEST(VecOps, CopyCtor)
+{
+   ROOT::Experimental::VecOps::TVec<int> v1{1,2,3};
+   ROOT::Experimental::VecOps::TVec<int> v2(v1);
+   EXPECT_EQ(v1.size(), 3u);
+   EXPECT_EQ(v2.size(), 3u);
+   // FIXME uncomment when operator[] is fixed
+   //EXPECT_EQ(v2[0], 1);
+   //EXPECT_EQ(v2[1], 2);
+   //EXPECT_EQ(v2[2], 3);
+}
+
+TEST(VecOps, MoveCtor)
+{
+   ROOT::Experimental::VecOps::TVec<int> v1{1,2,3};
+   ROOT::Experimental::VecOps::TVec<int> v2(std::move(v1));
+   EXPECT_EQ(v1.size(), 0u);
+   EXPECT_EQ(v2.size(), 3u);
+}
+
+TEST(VecOps, CopyStdVector)
+{
+   std::vector<double> v{1., 2., 3.};
+   ROOT::Experimental::VecOps::TVec<double> vec(v);
+   EXPECT_EQ(vec.size(), 3u);
+   // FIXME uncomment when operator[] is fixed
+   //EXPECT_DOUBLE_EQ(vec[0], 1.);
+   //EXPECT_DOUBLE_EQ(vec[1], 2.);
+   //EXPECT_DOUBLE_EQ(vec[2], 3.);
+}
+
+TEST(VecOps, MoveStdVector)
+{
+   std::vector<double> stdv{1., 2., 3.};
+   ROOT::Experimental::VecOps::TVec<double> tv(std::move(stdv));
+   EXPECT_EQ(stdv.size(), 0u);
+   EXPECT_EQ(tv.size(), 3u);
 }

--- a/test/vecops_unit.C
+++ b/test/vecops_unit.C
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+
+#include <ROOT/TVec.hxx>
+
+TEST(VecOps, DefaultCtor)
+{
+   ROOT::Experimental::VecOps::TVec<int>();
+}


### PR DESCRIPTION
Out-of-source builds should work out of the box and produce
`src/libVecOps.a` as well as `test/{intro,vecops_unit}`.